### PR TITLE
Use jenkins:lts-jdk11 as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,5 @@ RUN apt-get update && \
       $(lsb_release -cs) \
       stable" && \
    apt-get update && \
-   apt-get -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin
+   apt-get -y install docker-ce docker-ce-cli containerd.io docker-compose docker-compose-plugin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:lts
+FROM jenkins/jenkins:lts-jdk11
 MAINTAINER miiro@getintodevops.com
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,5 @@ RUN apt-get update && \
       $(lsb_release -cs) \
       stable" && \
    apt-get update && \
-   apt-get -y install docker-ce
+   apt-get -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin
 


### PR DESCRIPTION
The latest version of Jenkins requires Java 11 or greater. Referencing `jenkins/jenkins:lts-jdk11` as the base image allows the latest Jenkins to run successfully.